### PR TITLE
do not use cssnano-preset-default 8 at the moment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,8 @@ updates:
         versions: [ ">=8.0.0" ]
       - dependency-name: "cssnano"
         versions: [ ">=8.0.0" ]
+      - dependency-name: "cssnano-preset-default"
+        versions: [ ">=8.0.0" ]
 
     # Disable rebasing for all pull requests
     rebase-strategy: "disabled"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Abhängigkeitsverwaltungskonfiguration angepasst zur Optimierung der npm-Paketaktualisierungen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mimmi20/mezzio-sample-project/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->