### PR TITLE
do not use postcss-normalize-whitespace 8 at the moment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,6 +88,8 @@ updates:
         versions: [ ">=8.0.0" ]
       - dependency-name: "postcss-merge-rules"
         versions: [ ">=8.0.0" ]
+      - dependency-name: "postcss-normalize-whitespace"
+        versions: [ ">=8.0.0" ]
 
     # Disable rebasing for all pull requests
     rebase-strategy: "disabled"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Wartung**
  * Abhängigkeitsverwaltungskonfiguration angepasst.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mimmi20/mezzio-sample-project/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->